### PR TITLE
fix(*): Fix spelling error  - "occured" to "occurred" (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfs"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfs"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["Manuel Woelker <github@manuel.woelker.org>"]
 description = "A virtual filesystem for Rust"
 repository = "https://github.com/manuel-woelker/rust-vfs"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ feedback, please leave a comment on [issue #77](https://github.com/manuel-woelke
 ## Changelog
 
 
+### 0.13.0 (2026-03-21)
+
+* cargo: set MSRV to 1.63 to match CI environment
+* fix spelling errors (#85) - thanks [@JordanGoulder](https://github.com/JordanGoulder)!
+* fix broken link to `EmbeddedFS` for doc.rs. (#88) - thanks [James2022-rgb](https://github.com/James2022-rgb) and  [@Infinoid](https://github.com/Infinoid)!
+* document the feature flag `export-test-macros` in lib.rs - thanks [@feznyng](https://github.com/feznyng) for the reminder!
+
 ### 0.12.2 (2025-07-12)
 * Path: reduced memory allocations when joining paths  - thanks 
   [@landaire](https://github.com/landaire)!

--- a/src/async_vfs/path.rs
+++ b/src/async_vfs/path.rs
@@ -1025,7 +1025,7 @@ pub struct WalkDirIterator {
     // Used to store futures when poll_next returns pending
     // this ensures a new future is not spawned on each poll.
     read_dir_fut: Option<
-        BoxFuture<'static, Result<Box<(dyn Stream<Item = AsyncVfsPath> + Send + Unpin)>, VfsError>>,
+        BoxFuture<'static, Result<Box<dyn Stream<Item = AsyncVfsPath> + Send + Unpin>, VfsError>>,
     >,
     metadata_fut: Option<BoxFuture<'static, Result<VfsMetadata, VfsError>>>,
 }

--- a/src/async_vfs/test_macros.rs
+++ b/src/async_vfs/test_macros.rs
@@ -503,7 +503,7 @@ macro_rules! test_async_vfs {
 
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(
@@ -1245,7 +1245,7 @@ macro_rules! test_async_vfs_readonly {
                 /// Utility function for templating the same error message
                 // TODO: Maybe deduplicate this function
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ impl From<VfsErrorKind> for VfsError {
             //              never forgets to add a path. Might need a separate error type for FS impls vs VFS
             path: "PATH NOT FILLED BY VFS LAYER".into(),
             kind,
-            context: "An error occured".into(),
+            context: "An error occurred".into(),
             cause: None,
         }
     }
@@ -182,7 +182,7 @@ mod tests {
         let result = produce_anyhow_result().unwrap_err();
         assert_eq!(
             result.to_string(),
-            "An error occured for 'foo': FileSystem error: Not a file"
+            "An error occurred for 'foo': FileSystem error: Not a file"
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!  * **[`MemoryFS`](impls/memory/struct.MemoryFS.html)** - an ephemeral in-memory implementation (intended for unit tests)
 //!  * **[`AltrootFS`](impls/altroot/struct.AltrootFS.html)** - a file system with its root in a particular directory of another filesystem
 //!  * **[`OverlayFS`](impls/overlay/struct.OverlayFS.html)** - a union file system consisting of a read/writable upper layer and several read-only lower layers
-//!  * **[`EmbeddedFS`](impls/embedded/struct.EmbeddedFs.html)** - a read-only file system embedded in the executable, requires `embedded-fs` feature
+//!  * **[`EmbeddedFS`](impls/embedded/struct.EmbeddedFS.html)** - a read-only file system embedded in the executable, requires `embedded-fs` feature
 //!
 //! # Usage Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@
 //! # }
 //! ```
 //!
+//! # Feature flags
+//!
+//! - `export-test-macros`: exports the test macros `test_vfs!` and `test_vfs_readonly!` which can be used to test your own `FileSystem` implementations
 //!
 #![allow(unknown_lints)]
 #![allow(clippy::upper_case_acronyms)]

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -524,7 +524,7 @@ use super::*;
 
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(
@@ -1260,7 +1260,7 @@ macro_rules! test_vfs_readonly {
                 /// Utility function for templating the same error message
                 // TODO: Maybe deduplicate this function
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(


### PR DESCRIPTION
* Fix typo in error context message

Changed "occured" to "occurred"

* Fix typo in error message formatting

Change "occured" to "occurred"

* Fix typo in invalid_path_message function

Change "occured" to "occurred"

* Fix typo in error message

Change "occured" to "occurred"